### PR TITLE
Add Slack notification support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -57,7 +57,7 @@ flowchart TD
     
     Stats --> Notify{Notifications<br/>enabled?}
     
-    Notify --> |Yes + Changes| Send[Send Notification<br/>Gotify/ntfy/Discord/Telegram<br/>Per-host breakdown]
+    Notify --> |Yes + Changes| Send[Send Notification<br/>Gotify/ntfy/Discord/Telegram/Slack<br/>Per-host breakdown]
     Notify --> |No or No changes| Log[Write to<br/>prunemate.log]
     Send --> Log
     Log --> Done[Done]
@@ -115,17 +115,19 @@ flowchart TD
 
 ### Notification Flow
 
-- **Providers**: Gotify (self-hosted), ntfy.sh (pub-sub), Discord (webhooks), or Telegram (Bot API)
+- **Providers**: Gotify (self-hosted), ntfy.sh (pub-sub), Discord (webhooks), Telegram (Bot API), or Slack (Incoming Webhooks)
 - **Authentication**: 
   - Gotify: App tokens
   - ntfy: Bearer tokens, Basic Auth, or unauthenticated
   - Discord: Webhook URLs
   - Telegram: Bot Token + Chat ID
+  - Slack: Incoming Webhook URLs
 - **Priority System**: Text-based (Low/Medium/High) with provider-specific behavior
   - Gotify: Numeric mapping (Low=2, Medium=5, High=8)
   - ntfy: Numeric mapping (Low=2, Medium=3, High=5)
   - Discord: Color mapping (Low=Green, Medium=Orange, High=Red)
   - Telegram: Notification sound (Low=Silent, Medium/High=Sound)
+  - Slack: Color mapping (Low=good/green, Medium=warning/orange, High=danger/red)
 - **Smart Notifications**: Optional "only on changes" mode to reduce noise
 - **Per-host Breakdown**: Detailed results for each Docker host in multi-host setups
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Add external Docker hosts via [docker-socket-proxy](https://github.com/Tecnativa
 </p>
 
 ### Notification Settings
-Set up notifications via Gotify, ntfy.sh, Discord, or Telegram to stay informed about cleanup results.
+Set up notifications via Gotify, ntfy.sh, Discord, Telegram, or Slack to stay informed about cleanup results.
 
 <p align="center">
   <img width="400" height="400" alt="prunemate-notifications" src="https://github.com/user-attachments/assets/73a06c4d-fffa-40eb-a010-239d7d364004" /> 
@@ -261,8 +261,8 @@ Access the web interface at `http://localhost:7676/` (or your server IP) to conf
 - ☑️ All unused volumes
 
 **Notification Settings:**
-- **Provider:** Gotify, ntfy.sh, Discord, or Telegram
-- **Configuration:** Provider-specific credentials (URL/Token for Gotify, URL/Topic for ntfy, Webhook URL for Discord, Bot Token/Chat ID for Telegram)
+- **Provider:** Gotify, ntfy.sh, Discord, Telegram, or Slack
+- **Configuration:** Provider-specific credentials (URL/Token for Gotify, URL/Topic for ntfy, Webhook URL for Discord, Bot Token/Chat ID for Telegram, Webhook URL for Slack)
 - **Priority:** Low (silent), Medium, or High priority notifications (provider-dependent)
 - **Only notify on changes:** Only send notifications when something was actually cleaned
 
@@ -397,6 +397,26 @@ PruneMate tracks cumulative statistics across all prune runs:
 **Advanced usage:**
 - **Groups:** Add bot to group, get group Chat ID (starts with `-`)
 - **Channels:** Use channel username with `@` (e.g., `@mychannel`) or numeric ID
+
+---
+
+### Slack
+
+[Slack Incoming Webhooks](https://api.slack.com/messaging/webhooks) allow notifications directly to a Slack channel.
+
+**Setup:**
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) and create (or choose) an app
+2. Enable **Incoming Webhooks** in the app's feature settings
+3. Click **Add New Webhook to Workspace**, select your target channel, and click **Allow**
+4. Copy the generated webhook URL (starts with `https://hooks.slack.com/services/…`)
+5. In PruneMate notifications settings:
+   - **Provider:** Slack
+   - **Webhook URL:** The URL you copied above
+
+**Priority behavior:**
+- **Low:** Green attachment border (`good`)
+- **Medium:** Orange/yellow attachment border (`warning`)
+- **High:** Red attachment border (`danger`)
 
 ---
 

--- a/prunemate.py
+++ b/prunemate.py
@@ -57,6 +57,7 @@ DEFAULT_CONFIG = {
         "ntfy": {"enabled": False, "url": "", "topic": "", "token": ""},
         "discord": {"enabled": False, "webhook_url": ""},
         "telegram": {"enabled": False, "bot_token": "", "chat_id": ""},
+        "slack": {"enabled": False, "webhook_url": ""},
         "priority": "medium",
         "only_on_changes": True,
     },
@@ -494,7 +495,7 @@ def load_config(silent=False):
                 merged["notifications"] = json.loads(json.dumps(DEFAULT_CONFIG["notifications"]))
             
             # Ensure all provider subkeys exist (forward compatibility for new providers like telegram)
-            for provider_key in ["gotify", "ntfy", "discord", "telegram"]:
+            for provider_key in ["gotify", "ntfy", "discord", "telegram", "slack"]:
                 if provider_key not in merged["notifications"]:
                     merged["notifications"][provider_key] = json.loads(json.dumps(DEFAULT_CONFIG["notifications"][provider_key]))
             
@@ -783,8 +784,70 @@ def _send_telegram(cfg: dict, title: str, message: str, priority: str = "medium"
         return False
 
 
+def _send_slack(cfg: dict, title: str, message: str, priority: str = "medium") -> bool:
+    """Send a notification via Slack Incoming Webhook."""
+    if not cfg.get("enabled"):
+        log("Slack disabled; skipping notification.")
+        return False
+    webhook_url = (cfg.get("webhook_url") or "").strip()
+    if not webhook_url:
+        log("Slack enabled but webhook_url missing; skipping.")
+        return False
+
+    if not webhook_url.startswith("https://hooks.slack.com/"):
+        log(f"Invalid Slack webhook URL format: {webhook_url[:50]}...")
+        return False
+
+    # Map priority to Slack attachment color
+    color_map = {
+        "low": "good",      # Green
+        "medium": "warning", # Orange/Yellow
+        "high": "danger",   # Red
+    }
+    color = color_map.get(priority, "good")
+
+    payload = {
+        "attachments": [{
+            "fallback": f"{title}: {message}",
+            "color": color,
+            "title": title,
+            "text": message,
+            "ts": int(datetime.datetime.now(app_timezone).timestamp()),
+        }]
+    }
+
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        webhook_url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "PruneMate/1.3.2 (Docker cleanup bot)",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            log(f"Slack notification sent, status={getattr(resp, 'status', '?')}")
+            return True
+    except urllib.error.HTTPError as e:
+        error_body = ""
+        try:
+            error_body = e.read().decode("utf-8")
+        except Exception:
+            pass
+        log(f"Slack webhook HTTP error {e.code}: {e.reason}. Body: {error_body[:200]}")
+        return False
+    except urllib.error.URLError as e:
+        log(f"Slack webhook network error: {e.reason}")
+        return False
+    except Exception as e:
+        log(f"Failed to send Slack notification: {e}")
+        return False
+
+
 def send_notification(title: str, message: str, priority: str = "medium") -> bool:
-    """Send a notification using the configured provider (gotify, ntfy, discord, or telegram)."""
+    """Send a notification using the configured provider (gotify, ntfy, discord, telegram, or slack)."""
     notcfg = config.get("notifications", DEFAULT_CONFIG["notifications"])
     provider = (notcfg.get("provider") or "gotify").lower()
     if provider == "gotify":
@@ -795,6 +858,8 @@ def send_notification(title: str, message: str, priority: str = "medium") -> boo
         return _send_discord(notcfg.get("discord", {}), title, message, priority)
     if provider == "telegram":
         return _send_telegram(notcfg.get("telegram", {}), title, message, priority)
+    if provider == "slack":
+        return _send_slack(notcfg.get("slack", {}), title, message, priority)
     log(f"Unknown notification provider '{provider}'; skipping.")
     return False
 
@@ -1658,6 +1723,8 @@ def update():
     telegram_enabled = "telegram_enabled" in request.form
     telegram_bot_token = (request.form.get("telegram_bot_token") or "").strip()
     telegram_chat_id = (request.form.get("telegram_chat_id") or "").strip()
+    slack_enabled = "slack_enabled" in request.form
+    slack_webhook_url = (request.form.get("slack_webhook_url") or "").strip()
     # Parse notification priority (low/medium/high, default 'medium')
     notification_priority = request.form.get("notification_priority", "medium").strip().lower()
     if notification_priority not in ["low", "medium", "high"]:
@@ -1673,6 +1740,8 @@ def update():
         discord_enabled = True
     if provider == "telegram" and not telegram_enabled and telegram_bot_token and telegram_chat_id:
         telegram_enabled = True
+    if provider == "slack" and not slack_enabled and slack_webhook_url:
+        slack_enabled = True
 
     time_value = validate_time(time_value)
 
@@ -1693,6 +1762,7 @@ def update():
             "ntfy": {"enabled": ntfy_enabled, "url": ntfy_url, "topic": ntfy_topic, "token": ntfy_token},
             "discord": {"enabled": discord_enabled, "webhook_url": discord_webhook_url},
             "telegram": {"enabled": telegram_enabled, "bot_token": telegram_bot_token, "chat_id": telegram_chat_id},
+            "slack": {"enabled": slack_enabled, "webhook_url": slack_webhook_url},
             "priority": notification_priority,
             "only_on_changes": only_on_changes,
         },
@@ -1835,6 +1905,8 @@ def test_notification():
     telegram_enabled = "telegram_enabled" in request.form
     telegram_bot_token = (request.form.get("telegram_bot_token") or "").strip()
     telegram_chat_id = (request.form.get("telegram_chat_id") or "").strip()
+    slack_enabled = "slack_enabled" in request.form
+    slack_webhook_url = (request.form.get("slack_webhook_url") or "").strip()
     # Parse notification priority (low/medium/high, default 'medium')
     notification_priority = request.form.get("notification_priority", "medium").strip().lower()
     if notification_priority not in ["low", "medium", "high"]:
@@ -1850,6 +1922,8 @@ def test_notification():
         discord_enabled = True
     if provider == "telegram" and not telegram_enabled and telegram_bot_token and telegram_chat_id:
         telegram_enabled = True
+    if provider == "slack" and not slack_enabled and slack_webhook_url:
+        slack_enabled = True
 
     time_value = validate_time(time_value)
 
@@ -1869,6 +1943,7 @@ def test_notification():
             "ntfy": {"enabled": ntfy_enabled, "url": ntfy_url, "topic": ntfy_topic, "token": ntfy_token},
             "discord": {"enabled": discord_enabled, "webhook_url": discord_webhook_url},
             "telegram": {"enabled": telegram_enabled, "bot_token": telegram_bot_token, "chat_id": telegram_chat_id},
+            "slack": {"enabled": slack_enabled, "webhook_url": slack_webhook_url},
             "priority": notification_priority,
             "only_on_changes": only_on_changes,
         },

--- a/templates/index.html
+++ b/templates/index.html
@@ -717,6 +717,7 @@
                 <option value="ntfy" {% if config.notifications.provider == 'ntfy' %}selected{% endif %}>ntfy</option>
                 <option value="discord" {% if config.notifications.provider == 'discord' %}selected{% endif %}>Discord</option>
                 <option value="telegram" {% if config.notifications.provider == 'telegram' %}selected{% endif %}>Telegram</option>
+                <option value="slack" {% if config.notifications.provider == 'slack' %}selected{% endif %}>Slack</option>
               </select>
             </div>
             <!-- Notification priority selector -->
@@ -854,6 +855,26 @@
                 <input type="text" id="telegram_chat_id" name="telegram_chat_id"
                        value="{{ config.notifications.telegram.chat_id or '' }}"
                        placeholder="123456789 or @channelname" aria-label="Telegram chat ID or channel username">
+              </div>
+            </div>
+          </div>
+
+          <!-- Slack specific fields -->
+          <div id="slack-fields" style="margin-top:12px;display:none;">
+            <div class="toggle-row">
+              <span class="label-text" id="slack-enable-label">Enable Slack notifications</span>
+              <label class="switch">
+                <input type="checkbox" name="slack_enabled" id="slack_enabled" aria-labelledby="slack-enable-label"
+                       {% if config.notifications.slack.enabled %}checked{% endif %}>
+                <span class="slider"></span>
+              </label>
+            </div>
+            <div class="row" style="margin-top:6px;">
+              <div style="flex:1;">
+                <label for="slack_webhook_url">Slack Webhook URL :</label>
+                <input type="text" id="slack_webhook_url" name="slack_webhook_url"
+                       value="{{ config.notifications.slack.webhook_url or '' }}"
+                       placeholder="https://hooks.slack.com/services/..." aria-label="Slack incoming webhook URL">
               </div>
             </div>
           </div>
@@ -1087,14 +1108,16 @@
       const ntfyBlock = document.getElementById('ntfy-fields');
       const discordBlock = document.getElementById('discord-fields');
       const telegramBlock = document.getElementById('telegram-fields');
+      const slackBlock = document.getElementById('slack-fields');
       const toggleWrapper = document.getElementById('only-on-changes-wrapper');
-      if(!gotifyBlock || !ntfyBlock || !discordBlock || !telegramBlock || !toggleWrapper) return;
+      if(!gotifyBlock || !ntfyBlock || !discordBlock || !telegramBlock || !slackBlock || !toggleWrapper) return;
       // Show Gotify fields and position toggle
       if(prov === 'gotify'){
         gotifyBlock.style.display = 'block';
         ntfyBlock.style.display = 'none';
         discordBlock.style.display = 'none';
         telegramBlock.style.display = 'none';
+        slackBlock.style.display = 'none';
         if(gotifyBlock.firstElementChild){
           gotifyBlock.insertBefore(toggleWrapper, gotifyBlock.firstElementChild.nextSibling);
         } else {
@@ -1106,6 +1129,7 @@
         ntfyBlock.style.display = 'block';
         discordBlock.style.display = 'none';
         telegramBlock.style.display = 'none';
+        slackBlock.style.display = 'none';
         if(ntfyBlock.firstElementChild){
           ntfyBlock.insertBefore(toggleWrapper, ntfyBlock.firstElementChild.nextSibling);
         } else {
@@ -1117,6 +1141,7 @@
         ntfyBlock.style.display = 'none';
         discordBlock.style.display = 'block';
         telegramBlock.style.display = 'none';
+        slackBlock.style.display = 'none';
         if(discordBlock.firstElementChild){
           discordBlock.insertBefore(toggleWrapper, discordBlock.firstElementChild.nextSibling);
         } else {
@@ -1128,10 +1153,23 @@
         ntfyBlock.style.display = 'none';
         discordBlock.style.display = 'none';
         telegramBlock.style.display = 'block';
+        slackBlock.style.display = 'none';
         if(telegramBlock.firstElementChild){
           telegramBlock.insertBefore(toggleWrapper, telegramBlock.firstElementChild.nextSibling);
         } else {
           telegramBlock.appendChild(toggleWrapper);
+        }
+      // Show Slack fields and position toggle
+      } else if(prov === 'slack'){
+        gotifyBlock.style.display = 'none';
+        ntfyBlock.style.display = 'none';
+        discordBlock.style.display = 'none';
+        telegramBlock.style.display = 'none';
+        slackBlock.style.display = 'block';
+        if(slackBlock.firstElementChild){
+          slackBlock.insertBefore(toggleWrapper, slackBlock.firstElementChild.nextSibling);
+        } else {
+          slackBlock.appendChild(toggleWrapper);
         }
       }
     }


### PR DESCRIPTION
Coded with copilot

==

Adds Slack as a fifth notification provider via Incoming Webhooks, alongside the existing Gotify, ntfy, Discord, and Telegram providers.

### Backend (`prunemate.py`)
- New `_send_slack()` — POSTs to a Slack Incoming Webhook using the `attachments` API; URL validated against `https://hooks.slack.com/`; priority maps to Slack semantic colours (`good` / `warning` / `danger`)
- `DEFAULT_CONFIG` — new `slack: {enabled, webhook_url}` sub-dict
- `load_config()` — `"slack"` added to forward-compat provider subkey loop (silent migration for existing configs)
- `send_notification()` — `"slack"` dispatch branch added
- Both form handlers (`/save-config`, `/test-notification`) — read `slack_enabled` + `slack_webhook_url`; auto-enable logic consistent with other providers

### Frontend (`templates/index.html`)
- `<option value="slack">` added to provider `<select>`
- `#slack-fields` panel (enable toggle + webhook URL input) added, consistent with Discord panel layout
- `updateNotifUI()` extended to show/hide Slack panel and reposition the "only notify on changes" toggle

### Docs
- `ARCHITECTURE.md` — provider list and auth/priority tables updated
- `README.md` — provider lists updated; Slack setup section added (app creation, webhook URL, priority colour behaviour)